### PR TITLE
Modernize calculator UI and externalize assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,89 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Basic Calculator</title>
-  <style>
-    :root {
-      --btn-bg: #f0f0f0;
-      --btn-hover: #e0e0e0;
-      --btn-active: #d0d0d0;
-      --display-bg: #222;
-      --display-color: #fff;
-      --primary-color: #4CAF50;
-    }
-    .dark {
-      --btn-bg: #333;
-      --btn-hover: #444;
-      --btn-active: #555;
-      --display-bg: #000;
-      --display-color: #fff;
-      --primary-color: #81C784;
-    }
-    body.dark {
-      background: #333;
-    }
-    * {
-      box-sizing: border-box;
-    }
-    body {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      height: 100vh;
-      background: #fafafa;
-      margin: 0;
-      font-family: sans-serif;
-    }
-    .calculator {
-      border: 1px solid #ccc;
-      border-radius: 10px;
-      padding: 20px;
-      box-shadow: 0 4px 10px rgba(0,0,0,0.1);
-      background: #fff;
-    }
-    .display {
-      width: 100%;
-      height: 60px;
-      background: var(--display-bg);
-      color: var(--display-color);
-      text-align: right;
-      padding: 10px;
-      border-radius: 5px;
-      font-size: 2rem;
-      margin-bottom: 10px;
-      overflow-x: auto;
-    }
-    .buttons {
-      display: grid;
-      grid-template-columns: repeat(4, 60px);
-      grid-gap: 10px;
-    }
-    button {
-      width: 60px;
-      height: 60px;
-      font-size: 1.5rem;
-      border: none;
-      border-radius: 5px;
-      background: var(--btn-bg);
-      cursor: pointer;
-      transition: background 0.2s;
-    }
-    button:hover {
-      background: var(--btn-hover);
-    }
-    button:active {
-      background: var(--btn-active);
-    }
-    .operator {
-      background: var(--primary-color);
-      color: #fff;
-    }
-    .operator:hover {
-      background: #45a049;
-    }
-    .span-two {
-      grid-column: span 2;
-    }
-  </style>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <div class="calculator">
@@ -114,71 +35,6 @@
       <button class="operator" data-action="=">=</button>
     </div>
   </div>
-  <script>
-    const display = document.getElementById('display');
-    let firstOperand = null;
-    let operator = null;
-    let awaitingNext = false;
-
-    function calculate(a, b, operator) {
-      a = parseFloat(a);
-      b = parseFloat(b);
-      if (operator === '+') return a + b;
-      if (operator === '-') return a - b;
-      if (operator === '*') return a * b;
-      if (operator === '/') return b === 0 ? 'Error' : a / b;
-      if (operator === '%') return (a / 100) * b;
-      return b;
-    }
-
-    function updateDisplay(value) {
-      display.textContent = value;
-    }
-
-    document.querySelector('.buttons').addEventListener('click', e => {
-      const target = e.target;
-      if (!target.matches('button')) return;
-      if (target.dataset.number !== undefined) {
-        if (awaitingNext) {
-          updateDisplay(target.dataset.number);
-          awaitingNext = false;
-        } else {
-          if (target.dataset.number === '.' && display.textContent.includes('.')) return;
-          updateDisplay(display.textContent === '0' ? target.dataset.number : display.textContent + target.dataset.number);
-        }
-      }
-      if (target.dataset.action) {
-        const action = target.dataset.action;
-        if (action === 'clear') {
-          updateDisplay('0');
-          firstOperand = null;
-          operator = null;
-          awaitingNext = false;
-        } else if (action === 'delete') {
-          const current = display.textContent.slice(0, -1) || '0';
-          updateDisplay(current);
-        } else if (action === '=') {
-          if (operator === null || awaitingNext) return;
-          const result = calculate(firstOperand, display.textContent, operator);
-          updateDisplay(result);
-          firstOperand = result;
-          operator = null;
-          awaitingNext = true;
-        } else if (action === 'toggle-theme') {
-          document.body.classList.toggle('dark');
-        } else {
-          if (firstOperand !== null && operator) {
-            const result = calculate(firstOperand, display.textContent, operator);
-            updateDisplay(result);
-            firstOperand = result;
-          } else {
-            firstOperand = display.textContent;
-          }
-          operator = action;
-          awaitingNext = true;
-        }
-      }
-    });
-  </script>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,64 @@
+const display = document.getElementById('display');
+let firstOperand = null;
+let operator = null;
+let awaitingNext = false;
+
+function calculate(a, b, operator) {
+  a = parseFloat(a);
+  b = parseFloat(b);
+  if (operator === '+') return a + b;
+  if (operator === '-') return a - b;
+  if (operator === '*') return a * b;
+  if (operator === '/') return b === 0 ? 'Error' : a / b;
+  if (operator === '%') return (a / 100) * b;
+  return b;
+}
+
+function updateDisplay(value) {
+  display.textContent = value;
+}
+
+document.querySelector('.buttons').addEventListener('click', e => {
+  const target = e.target;
+  if (!target.matches('button')) return;
+  if (target.dataset.number !== undefined) {
+    if (awaitingNext) {
+      updateDisplay(target.dataset.number);
+      awaitingNext = false;
+    } else {
+      if (target.dataset.number === '.' && display.textContent.includes('.')) return;
+      updateDisplay(display.textContent === '0' ? target.dataset.number : display.textContent + target.dataset.number);
+    }
+  }
+  if (target.dataset.action) {
+    const action = target.dataset.action;
+    if (action === 'clear') {
+      updateDisplay('0');
+      firstOperand = null;
+      operator = null;
+      awaitingNext = false;
+    } else if (action === 'delete') {
+      const current = display.textContent.slice(0, -1) || '0';
+      updateDisplay(current);
+    } else if (action === '=') {
+      if (operator === null || awaitingNext) return;
+      const result = calculate(firstOperand, display.textContent, operator);
+      updateDisplay(result);
+      firstOperand = result;
+      operator = null;
+      awaitingNext = true;
+    } else if (action === 'toggle-theme') {
+      document.body.classList.toggle('dark');
+    } else {
+      if (firstOperand !== null && operator) {
+        const result = calculate(firstOperand, display.textContent, operator);
+        updateDisplay(result);
+        firstOperand = result;
+      } else {
+        firstOperand = display.textContent;
+      }
+      operator = action;
+      awaitingNext = true;
+    }
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,96 @@
+:root {
+  --bg-gradient: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+  --btn-bg: #ffffff;
+  --btn-hover: #e2e8f0;
+  --btn-active: #cbd5e0;
+  --display-bg: #1a202c;
+  --display-color: #ffffff;
+  --primary-color: #4CAF50;
+  --primary-hover: #45a049;
+}
+
+.dark {
+  --bg-gradient: linear-gradient(135deg, #2d3748, #1a202c);
+  --btn-bg: #2d3748;
+  --btn-hover: #4a5568;
+  --btn-active: #718096;
+  --display-bg: #000000;
+  --display-color: #ffffff;
+  --primary-color: #81C784;
+  --primary-hover: #66bb6a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background: var(--bg-gradient);
+  margin: 0;
+  font-family: 'Roboto', sans-serif;
+}
+
+.calculator {
+  border: 1px solid #ccc;
+  border-radius: 10px;
+  padding: 30px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+  background: #fff;
+}
+
+.display {
+  width: 100%;
+  height: 70px;
+  background: var(--display-bg);
+  color: var(--display-color);
+  text-align: right;
+  padding: 15px;
+  border-radius: 5px;
+  font-size: 2rem;
+  margin-bottom: 15px;
+  overflow-x: auto;
+  transition: all 0.3s ease;
+}
+
+.buttons {
+  display: grid;
+  grid-template-columns: repeat(4, 70px);
+  grid-gap: 15px;
+}
+
+button {
+  width: 70px;
+  height: 70px;
+  font-size: 1.5rem;
+  border: none;
+  border-radius: 5px;
+  background: var(--btn-bg);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  padding: 0;
+}
+
+button:hover {
+  background: var(--btn-hover);
+}
+
+button:active {
+  background: var(--btn-active);
+}
+
+.operator {
+  background: var(--primary-color);
+  color: #fff;
+}
+
+.operator:hover {
+  background: var(--primary-hover);
+}
+
+.span-two {
+  grid-column: span 2;
+}


### PR DESCRIPTION
## Summary
- Switch to Roboto from Google Fonts and link external CSS/JS for cleaner markup.
- Refresh styling with new color variables, gradients, larger button targets, and smooth transitions.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68956e5114d4832aa3b4ffc9e336919e