### PR TITLE
Improve calculator layout with centered column

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,12 @@
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
-  <header>
-    <h1>Basic Calculator</h1>
-  </header>
-  <div class="calculator">
-    <div class="display" id="display">0</div>
+  <body>
+    <div class="calculator">
+      <header>
+        <h1>Basic Calculator</h1>
+      </header>
+      <div class="display" id="display">0</div>
     <div class="buttons">
       <button class="operator" data-action="clear">C</button>
       <button class="operator" data-action="delete">DEL</button>

--- a/styles.css
+++ b/styles.css
@@ -26,8 +26,10 @@
 
 body {
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+  text-align: center;
   min-height: 100vh;
   background: var(--bg-gradient);
   margin: 0;
@@ -40,6 +42,7 @@ body {
   padding: 30px;
   box-shadow: 0 4px 10px rgba(0,0,0,0.1);
   background: #fff;
+  margin-top: 1rem;
 }
 
 .display {


### PR DESCRIPTION
## Summary
- Set body to column flex layout and center text for a single-column design.
- Add top margin to calculator container.
- Nest header within calculator wrapper for consistent centering.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689575755794832a922e685aeb6d26d6