### PR TITLE
Move theme toggle button to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <div class="calculator">
       <header>
         <h1>Basic Calculator</h1>
+        <button class="operator theme-toggle" data-action="toggle-theme">🌓</button>
       </header>
       <div class="display" id="display">0</div>
     <div class="buttons">
@@ -20,7 +21,6 @@
       <button class="operator" data-action="delete">DEL</button>
       <button class="operator" data-action="%">%</button>
       <button class="operator" data-action="/">÷</button>
-      <button class="operator" data-action="toggle-theme">🌓</button>
       <button data-number="7">7</button>
       <button data-number="8">8</button>
       <button data-number="9">9</button>

--- a/script.js
+++ b/script.js
@@ -47,8 +47,6 @@ document.querySelector('.buttons').addEventListener('click', e => {
       firstOperand = result;
       operator = null;
       awaitingNext = true;
-    } else if (action === 'toggle-theme') {
-      document.body.classList.toggle('dark');
     } else {
       if (firstOperand !== null && operator) {
         const result = calculate(firstOperand, display.textContent, operator);
@@ -61,4 +59,8 @@ document.querySelector('.buttons').addEventListener('click', e => {
       awaitingNext = true;
     }
   }
+});
+
+document.querySelector('[data-action="toggle-theme"]').addEventListener('click', () => {
+  document.body.classList.toggle('dark');
 });

--- a/styles.css
+++ b/styles.css
@@ -45,6 +45,10 @@ body {
   margin-top: 1rem;
 }
 
+header {
+  position: relative;
+}
+
 .display {
   width: 100%;
   height: 70px;
@@ -96,4 +100,13 @@ button:active {
 
 .span-two {
   grid-column: span 2;
+}
+
+.theme-toggle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 40px;
+  height: 40px;
+  font-size: 1rem;
 }


### PR DESCRIPTION
## Summary
- Relocate theme toggle button from calculator grid to header for cleaner 4-column layout.
- Add header-relative positioning and custom styles for new theme toggle button.
- Adjust script to listen for theme toggling outside button grid.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689577b352f0832a92577d7a1f58b02f