### PR TITLE
feat: refresh calculator with modern apple style

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,38 +4,35 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>My Calculator</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
   <body>
     <div class="calculator">
       <header>
         <h1>My Calculator</h1>
-        <button class="operator theme-toggle" data-action="toggle-theme">🌓</button>
+        <button class="theme-toggle" data-action="toggle-theme" aria-label="Toggle dark mode"></button>
       </header>
-      <div class="display" id="display">0</div>
+      <div class="display" id="display" aria-live="polite">0</div>
     <div class="buttons">
-      <button class="operator" data-action="clear">C</button>
-      <button class="operator" data-action="delete">DEL</button>
-      <button class="operator" data-action="%">%</button>
-      <button class="operator" data-action="/">÷</button>
+      <button class="operator" data-action="clear" aria-label="clear">C</button>
+      <button class="operator" data-action="delete" aria-label="delete">DEL</button>
+      <button class="operator" data-action="%" aria-label="percent">%</button>
+      <button class="operator" data-action="/" aria-label="divide">÷</button>
       <button data-number="7">7</button>
       <button data-number="8">8</button>
       <button data-number="9">9</button>
-      <button class="operator" data-action="*">×</button>
+      <button class="operator" data-action="*" aria-label="multiply">×</button>
       <button data-number="4">4</button>
       <button data-number="5">5</button>
       <button data-number="6">6</button>
-      <button class="operator" data-action="-">−</button>
+      <button class="operator" data-action="-" aria-label="subtract">−</button>
       <button data-number="1">1</button>
       <button data-number="2">2</button>
       <button data-number="3">3</button>
-      <button class="operator" data-action="+">+</button>
+      <button class="operator" data-action="+" aria-label="add">+</button>
       <button data-number="0" class="span-two">0</button>
-      <button data-number=".">.</button>
-      <button class="operator" data-action="=">=</button>
+      <button data-number="." aria-label="decimal point">.</button>
+      <button class="operator" data-action="=" aria-label="equals">=</button>
     </div>
   </div>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -61,6 +61,18 @@ document.querySelector('.buttons').addEventListener('click', e => {
   }
 });
 
-document.querySelector('[data-action="toggle-theme"]').addEventListener('click', () => {
+const themeToggleBtn = document.querySelector('[data-action="toggle-theme"]');
+
+const sunIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>';
+const moonIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z"></path></svg>';
+
+function updateThemeIcon() {
+  themeToggleBtn.innerHTML = document.body.classList.contains('dark') ? sunIcon : moonIcon;
+}
+
+themeToggleBtn.addEventListener('click', () => {
   document.body.classList.toggle('dark');
+  updateThemeIcon();
 });
+
+updateThemeIcon();

--- a/styles.css
+++ b/styles.css
@@ -1,23 +1,25 @@
 :root {
-  --bg-gradient: linear-gradient(135deg, #f5f7fa, #c3cfe2);
-  --btn-bg: #ffffff;
-  --btn-hover: #e2e8f0;
-  --btn-active: #cbd5e0;
-  --display-bg: #1a202c;
-  --display-color: #ffffff;
-  --primary-color: #4CAF50;
-  --primary-hover: #45a049;
+  --bg-gradient: linear-gradient(180deg, #FFFFFF, #F2F2F7);
+  --btn-bg: #F2F2F7;
+  --btn-hover: #E5E5EA;
+  --btn-active: #D1D1D6;
+  --display-bg: rgba(28,28,30,0.6);
+  --display-color: #000;
+  --primary-color: #007AFF;
+  --primary-hover: #005BBB;
+  --icon-color: invert(0);
 }
 
 .dark {
-  --bg-gradient: linear-gradient(135deg, #2d3748, #1a202c);
-  --btn-bg: #2d3748;
-  --btn-hover: #4a5568;
-  --btn-active: #718096;
-  --display-bg: #000000;
-  --display-color: #ffffff;
-  --primary-color: #81C784;
-  --primary-hover: #66bb6a;
+  --bg-gradient: linear-gradient(180deg, #1C1C1E, #2C2C2E);
+  --btn-bg: #2C2C2E;
+  --btn-hover: #3A3A3C;
+  --btn-active: #48484A;
+  --display-bg: rgba(255,255,255,0.1);
+  --display-color: #fff;
+  --primary-color: #0A84FF;
+  --primary-hover: #0060DF;
+  --icon-color: invert(1);
 }
 
 * {
@@ -33,15 +35,16 @@ body {
   min-height: 100vh;
   background: var(--bg-gradient);
   margin: 0;
-  font-family: 'Roboto', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif;
 }
 
 .calculator {
-  border: 1px solid #ccc;
-  border-radius: 10px;
+  background: rgba(255,255,255,0.6);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-radius: 20px;
   padding: 30px;
-  box-shadow: 0 4px 10px rgba(0,0,0,0.1);
-  background: #fff;
+  box-shadow: 0 4px 15px rgba(0,0,0,0.1);
   margin-top: 1rem;
 }
 
@@ -56,37 +59,50 @@ header {
   color: var(--display-color);
   text-align: right;
   padding: 15px;
-  border-radius: 5px;
+  border-radius: 16px;
   font-size: 2rem;
   margin-bottom: 15px;
   overflow-x: auto;
   transition: all 0.3s ease;
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
 }
 
 .buttons {
   display: grid;
-  grid-template-columns: repeat(4, 70px);
-  grid-gap: 15px;
+  grid-template-columns: repeat(4, minmax(50px, 1fr));
+  gap: 0.75rem;
 }
 
 button {
-  width: 70px;
-  height: 70px;
-  font-size: 1.5rem;
   border: none;
-  border-radius: 5px;
+  border-radius: 12px;
   background: var(--btn-bg);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
   cursor: pointer;
-  transition: all 0.3s ease;
+  transition: transform 0.05s ease, box-shadow 0.05s ease;
   padding: 0;
 }
 
+.buttons button {
+  width: 100%;
+  aspect-ratio: 1/1;
+  max-width: 80px;
+  font-size: 1.5rem;
+}
+
 button:hover {
-  background: var(--btn-hover);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.15);
 }
 
 button:active {
-  background: var(--btn-active);
+  transform: scale(0.97);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+}
+
+button:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
 }
 
 .operator {
@@ -100,6 +116,7 @@ button:active {
 
 .span-two {
   grid-column: span 2;
+  aspect-ratio: 2/1;
 }
 
 .theme-toggle {
@@ -108,5 +125,32 @@ button:active {
   right: 0;
   width: 40px;
   height: 40px;
-  font-size: 1rem;
+  background: transparent;
+  box-shadow: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.theme-toggle svg {
+  width: 24px;
+  height: 24px;
+  filter: var(--icon-color);
+}
+
+@media (max-width: 480px) {
+  .calculator {
+    padding: 20px;
+  }
+  .buttons {
+    gap: 0.5rem;
+  }
+  .buttons button {
+    max-width: 60px;
+    font-size: 1.25rem;
+  }
+  .display {
+    font-size: 1.5rem;
+    padding: 10px;
+  }
 }


### PR DESCRIPTION
## Summary
- adopt SF system fonts and neutral palette for a modern Apple aesthetic
- add frosted glass and responsive grid with animated buttons
- swap theme toggle emoji for SVG icon with aria labels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895738724b0832a8bf5523b9f4b7731